### PR TITLE
Fix: Test 목록 조회와 Test Result 조회 API 응답 오류 수정

### DIFF
--- a/mbti_service/src/core/test.result/application/data.access/test.result.store.interface.ts
+++ b/mbti_service/src/core/test.result/application/data.access/test.result.store.interface.ts
@@ -1,6 +1,6 @@
 import { TestResultModel } from '../../domain/test.result.model';
 
 export interface ITestResultStore {
-  create(testResult: TestResultModel): Promise<void>;
+  create(testResult: TestResultModel): Promise<number>;
   updateUserId(resultId: number, userId: number): Promise<void>;
 }

--- a/mbti_service/src/core/test.result/domain/test.result.model.ts
+++ b/mbti_service/src/core/test.result/domain/test.result.model.ts
@@ -13,12 +13,12 @@ export class TestResultModel {
 
   constructor(input: TestResultContructorInput) {
     this.id = input.id;
+    this.testId = input.testId;
     this.userId = input.userId;
     this.EIResult = input.EIResult;
     this.NSResult = input.NSResult;
     this.FTResult = input.FTResult;
     this.JPResult = input.JPResult;
-    this.createdAt = input.createdAt;
     this.destination = new Destination(input.destination);
   }
 
@@ -39,6 +39,7 @@ export class TestResultModel {
   public getProperteis() {
     return {
       id: this.id,
+      testId: this.testId,
       userId: this.userId,
       EIResult: this.EIResult,
       NSResult: this.NSResult,

--- a/mbti_service/src/core/test.result/infrastructure/entity/test.result.entity.ts
+++ b/mbti_service/src/core/test.result/infrastructure/entity/test.result.entity.ts
@@ -32,7 +32,6 @@ export class TestResultEntity {
   @Column()
   JPResult: number;
 
-  @OneToOne(() => DestinationEntity)
   @JoinColumn()
   destination: DestinationEntity;
 

--- a/mbti_service/src/core/test.result/infrastructure/test.result.repository.interface.ts
+++ b/mbti_service/src/core/test.result/infrastructure/test.result.repository.interface.ts
@@ -4,7 +4,7 @@ import { MBTI } from '../domain/vo/mbti.vo';
 
 export interface ITestResultRepository {
   getByUserId(userId: number): Promise<TestResultModel>;
-  create(testResult: TestResultModel): Promise<void>;
+  create(testResult: TestResultModel): Promise<number>;
   getDestinationByMbti(mbti: MBTI): Promise<Destination>;
   getById(resultId: number): Promise<TestResultModel>;
   updateUserId(testId: number, userId: number): Promise<void>;

--- a/mbti_service/src/core/test.result/infrastructure/test.result.repository.ts
+++ b/mbti_service/src/core/test.result/infrastructure/test.result.repository.ts
@@ -23,7 +23,7 @@ export class TestResultRepository implements ITestResultRepository {
       })
       .getOne();
 
-    await this.dataSource
+    let insertResult = await this.dataSource
       .createQueryBuilder()
       .insert()
       .into(TestResultEntity)
@@ -32,6 +32,8 @@ export class TestResultRepository implements ITestResultRepository {
         destination: destinationEntity,
       })
       .execute();
+
+    return insertResult.generatedMaps[0].id;
   }
 
   async getByUserId(userId: number) {

--- a/mbti_service/src/core/test.result/infrastructure/test.result.store.ts
+++ b/mbti_service/src/core/test.result/infrastructure/test.result.store.ts
@@ -11,7 +11,7 @@ export class TestResultStore implements ITestResultStore {
   ) {}
 
   async create(testResult: TestResultModel) {
-    await this.testResultRepository.create(testResult);
+    return await this.testResultRepository.create(testResult);
   }
 
   async updateUserId(testId: number, userId: number): Promise<void> {

--- a/mbti_service/src/core/test/application/info/submit.test.info.ts
+++ b/mbti_service/src/core/test/application/info/submit.test.info.ts
@@ -8,10 +8,10 @@ export class SubmitTestInfo {
   readonly destinationContentImgUrl: string;
   readonly mbti: string;
 
-  constructor(testResult: TestResultModel) {
+  constructor(resultId: number, testResult: TestResultModel) {
     const properties = testResult.getProperteis();
     const destination = properties.destination;
-    this.resultId = properties.id;
+    this.resultId = resultId;
     this.destinationName = destination.name;
     this.destinationImgUrl = destination.imgUrl;
     this.destinationContent = destination.content;

--- a/mbti_service/src/core/test/application/test.service.ts
+++ b/mbti_service/src/core/test/application/test.service.ts
@@ -44,7 +44,7 @@ export class TestService implements TestUseCase {
       testId,
       destination,
     );
-    await this.testResultStore.create(testResult);
-    return new SubmitTestInfo(testResult);
+    const resultId = await this.testResultStore.create(testResult);
+    return new SubmitTestInfo(resultId, testResult);
   }
 }

--- a/mbti_service/src/core/test/domain/test.model.ts
+++ b/mbti_service/src/core/test/domain/test.model.ts
@@ -11,7 +11,7 @@ export class TestModel {
     this.id = inputData.id;
     this.name = inputData.name;
     this.imgUrl = inputData.imgUrl;
-    this.questions = inputData.questions.map(
+    this.questions = inputData.questions?.map(
       (questionSet) => new Question({ ...questionSet }),
     );
   }


### PR DESCRIPTION
## TODO
- `/tests 와 /tests/{testId}/results` 조회 시, `500 ERROR` 해결

## 참고 사항
- localhost + 배포 DB 환경에서 코드를 수정하여, 현재 실행 가능하게 고친 상태입니다

- url을 수정하는 지난 커밋에서 main -> main 으로 바로 코드를 수정하신 것 같아서, 일단 main으로 PR 날립니다. 아니라면 다시 PR 생성하겠습니다.

- 주요 에러와 제가 해결한 방법입니다. 참고용으로 보시면 됩니다.


### test 조회 오류 로그
>

***ERROR [ExceptionsHandler] Cannot read properties of null (reading 'map')
TypeError: Cannot read properties of null (reading 'map')***

- 필드 map 하는데 null 값이 있어 오류 발생함. ?를 붙여 optional한 값도 받게 변경

### Submit API 오류 로그


***query failed: INSERT INTO `test_result`(`id`, `user_id`, `test_id`, `ei_result`, `ns_result`,
`ft_result`, `jp_result`, `created_at`, `destination_id`) VALUES (?, ?, DEFAULT, ?, ?, ?, ?, ?, ?) -- PARAMETERS: [null,null,1,0,0,0,null,1]
error: Error: Field 'test_id' doesn't have a default value
[Nest] 2380 - 2023. 07. 05. 오후 4:16:05 ERROR [ExceptionsHandler] Field 'test_id' doesn't have a default value
QueryFailedError: Field 'test_id' doesn't have a default value***

> TestResultModel 클래스 생성자에 testId 설정이 되지 않아, 파라미터로 넘어가지 못해 sql문이 default 로 value를 넣고 있었던 것으로 보임. 생성자에 추가하니 해결

***query failed: INSERT INTO `test_result`(`id`, `user_id`, `test_id`, `ei_result`, `ns_result`,
`ft_result`, `jp_result`, `created_at`, `destination_id`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) -- PARAMETERS: [null,null,1,1,0,0,0,null,1]
error: Error: Duplicate entry '1' for key 'test_result.REL_dbda867f5078f776927813967b'
[Nest] 32488 - 2023. 07. 05. 오후 4:19:25 ERROR [ExceptionsHandler] Duplicate entry '1' for key 'test_result.REL_dbda867f5078f776927813967b'
QueryFailedError: Duplicate entry '1' for key 'test_result.REL_dbda867f5078f776927813967b'***

> TestResult는 destinationId를 중복으로 가질 수 있어야하는데, OneToOne으로 설정해서 destinationId 컬럼이 unique 처리 되어 있는 상태. DB Tool 로 강제 unique 설정 제거. Entity에 @ OneToOne 어노테이션도 제거하여 실행 시 제약이 생기지 않도록 함
(제거하지 않으면 실행시 동일 오류 발생)

***ERROR [ExceptionsHandler] Column 'created_at' cannot be null***

- > insert query 에 created_at = null 넣지 않게 생성자를 수정하니 default로 insert가 되어 해결

- 마지막으로, 에러가 안 났는데 resultId 가 response로 받아와지지 않고 null 값이어서, 해당 부분을 가져오는 코드를 추가함
